### PR TITLE
ci: fix broken test matrix + add security scanning (govulncheck, Trivy, SBOM)

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,83 @@
+name: Security
+
+on:
+  push:
+    branches: [master, main]
+    paths-ignore:
+      - '**.md'
+  pull_request:
+    paths-ignore:
+      - '**.md'
+  schedule:
+    # Run weekly on Monday 08:00 UTC to catch newly published CVEs
+    - cron: '0 8 * * 1'
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  govulncheck:
+    name: Go Vulnerability Check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch Repository
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.22'
+          cache: true
+
+      - name: Install govulncheck
+        run: go install golang.org/x/vuln/cmd/govulncheck@latest
+
+      - name: Run govulncheck
+        run: govulncheck ./...
+
+  trivy-fs:
+    name: Trivy Filesystem Scan
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch Repository
+        uses: actions/checkout@v4
+
+      - name: Run Trivy (filesystem)
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          scan-type: fs
+          scan-ref: .
+          trivy-config: .trivy.yaml
+          format: sarif
+          output: trivy-results.sarif
+          severity: HIGH,CRITICAL
+          exit-code: '1'
+
+      - name: Upload Trivy SARIF to GitHub Security tab
+        if: always()
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: trivy-results.sarif
+
+  sbom:
+    name: Generate SBOM
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch Repository
+        uses: actions/checkout@v4
+
+      - name: Generate SBOM with Trivy
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          scan-type: fs
+          scan-ref: .
+          format: cyclonedx
+          output: sbom.cdx.json
+
+      - name: Upload SBOM artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: sbom-cyclonedx
+          path: sbom.cdx.json
+          retention-days: 90

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,17 +13,21 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: [1.13.x, 1.14.x]
+        go-version: ['1.22.x', '1.23.x']
         platform: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.platform }}
     steps:
-      - name: Setup Go ${{ matrix.go }}
-        uses: actions/setup-go@v1
+      - name: Fetch Repository
+        uses: actions/checkout@v4
+
+      - name: Setup Go ${{ matrix.go-version }}
+        uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go-version }}
-      - name: Fetch Repository
-        uses: actions/checkout@v2
+          cache: true
+
       - name: Build
         run: go build -v .
+
       - name: Test
         run: go test ./... -v

--- a/.trivy.yaml
+++ b/.trivy.yaml
@@ -1,0 +1,10 @@
+scan:
+  skip-dirs:
+    - vendor
+    - testdata
+
+vulnerability:
+  ignore-unfixed: false
+
+misconfiguration:
+  include-non-failures: false


### PR DESCRIPTION
## What

Two CI improvements in a single PR:

1. **Fix the broken test matrix** — all 6 matrix jobs were failing at `Setup Go` because `actions/setup-go@v1` no longer supports Go 1.13.x / 1.14.x.
2. **Add a security scanning workflow** — govulncheck, Trivy filesystem scan, and SBOM generation.

## Why the test was broken

`actions/setup-go@v1` reached end-of-life and no longer resolves `1.13.x` / `1.14.x` toolchains. Every push and PR was silently red.

## Changes

**`.github/workflows/test.yml`**
- `actions/checkout@v2` → `@v4`
- `actions/setup-go@v1` → `@v5` (with `cache: true`)
- Go matrix: `[1.13.x, 1.14.x]` → `[1.22.x, 1.23.x]`
- Keeps ubuntu / macos / windows cross-platform matrix

**`.github/workflows/security.yml`** — three parallel jobs:

| Job | Tool | Purpose |
|---|---|---|
| `govulncheck` | `golang.org/x/vuln` | Detect known CVEs via the Go vuln DB |
| `trivy-fs` | Trivy 0.28 | Filesystem scan; SARIF → GitHub Security tab |
| `sbom` | Trivy (CycloneDX) | SBOM artifact retained for 90 days |

**`.trivy.yaml`** — skips `vendor/` and `testdata/`.

## Test plan

- [ ] All 6 matrix jobs pass (ubuntu / macos / windows × 1.22 / 1.23)
- [ ] `govulncheck ./...` exits 0
- [ ] Trivy scan completes without blocking HIGH/CRITICAL findings
- [ ] SBOM artifact downloadable from the Actions run